### PR TITLE
bugfix - binder does not throw NullReferenceException for unspecified properties

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -35,4 +35,4 @@ jobs:
       run: dotnet build --no-restore
     
     - name: Test
-      run: dotnet test --no-build --verbosity normal
+      run: dotnet test --v m

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-[![Version](https://img.shields.io/nuget/v/MoqMicrosoftConfiguration?style=plastic)](https://www.nuget.org/packages/MoqMicrosoftConfiguration/)  
+[![Version](https://img.shields.io/nuget/v/MoqMicrosoftConfiguration?style=plastic)](https://www.nuget.org/packages/MoqMicrosoftConfiguration/)
+[![Nuget downloads](https://img.shields.io/nuget/dt/MoqMicrosoftConfiguration?label=nuget%20downloads&logo=nuget&style=plastic)](https://www.nuget.org/packages/MoqMicrosoftConfiguration/)   
 Moq for Microsoft.Extensions.Configuration
 ***
 Access values by specifying a path to the value in `[]` and with `:`.

--- a/src/Moq.Microsoft.Configuration.csproj
+++ b/src/Moq.Microsoft.Configuration.csproj
@@ -6,7 +6,7 @@
 		<LangVersion>latest</LangVersion>
 		<PackageId>MoqMicrosoftConfiguration</PackageId>
 		<ApplicationIcon>favico.ico</ApplicationIcon>
-		<Version>1.0.3.0</Version>
+		<Version>1.0.4</Version>
 		<Authors>Moq contributors</Authors>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<PackageProjectUrl>https://github.com/moq</PackageProjectUrl>

--- a/src/Utils/ConfigurationSetupExtensions.cs
+++ b/src/Utils/ConfigurationSetupExtensions.cs
@@ -8,6 +8,7 @@ namespace Moq.Microsoft.Configuration
 	internal static class ConfigurationSetupExtensions
 	{
 		private static readonly SectionInfoProvider SectionInfoProvider = new();
+		//private static readonly IConfigurationRoot
 
 		public static void SetupConfigurationTree(this ConfigurationSetup @this, object configuration)
 		{
@@ -20,6 +21,11 @@ namespace Moq.Microsoft.Configuration
 
 			if (props.Count == 0)
 				throw new InvalidOperationException("The root element has no properties");
+
+			// When a section is not found, a default section is returned instead
+			@this.MockConfiguration
+				.Setup(x => x.GetSection(It.IsAny<string>()))
+				.Returns((string x) => new ConfigurationSection(x));
 
 			var children = new IConfigurationSection[props.Count];
 			for (var i = 0; i < props.Count; i++)

--- a/src/Utils/Helpers/ConfigurationSection.cs
+++ b/src/Utils/Helpers/ConfigurationSection.cs
@@ -1,0 +1,36 @@
+﻿using System.Collections.Generic;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Primitives;
+
+namespace Moq.Microsoft.Configuration
+{
+	internal sealed class ConfigurationSection : IConfigurationSection
+	{
+		public ConfigurationSection(string key)
+		{
+			Key = key;
+			Path = $"Unknown:{key}";
+		}
+
+		public string Key { get; }
+
+		public string Path { get; }
+
+		public string? Value { get; set; }
+
+		public IConfigurationSection GetSection(string key) =>
+			throw new System.NotImplementedException();
+
+		public IEnumerable<IConfigurationSection> GetChildren() =>
+			throw new System.NotImplementedException();
+
+		public IChangeToken GetReloadToken() =>
+			throw new System.NotImplementedException();
+
+		public string this[string key]
+		{
+			get => throw new System.NotImplementedException();
+			set => throw new System.NotImplementedException();
+		}
+	}
+}

--- a/tests/Moq.Microsoft.Configuration.Tests/ConfigurationSetupTests/ReturnsShould.cs
+++ b/tests/Moq.Microsoft.Configuration.Tests/ConfigurationSetupTests/ReturnsShould.cs
@@ -171,5 +171,37 @@ namespace Moq.Microsoft.Configuration.Tests.ConfigurationSetupTests
 					.BeEquivalentTo(value.Items[i]);
 			}
 		}
+
+		[Fact]
+		public void NotThrowNullRefForUnspecifiedSections()
+		{
+			const int intValue = 123, fallbackValue = -1234;
+
+			var value = new
+			{
+				Set = intValue
+			};
+
+			var fixture = CreateClass();
+
+			fixture
+				.SetupConfiguration()
+				.Returns(value);
+
+			fixture.Object
+				.GetValue<int>(nameof(value.Set))
+				.Should()
+				.Be(intValue);
+
+			fixture.Object
+				.GetValue<int>("NotSet")
+				.Should()
+				.Be(0);
+
+			fixture.Object
+				.GetValue("NotSet", fallbackValue)
+				.Should()
+				.Be(fallbackValue);
+		}
 	}
 }

--- a/tests/Moq.Microsoft.Configuration.Tests/Moq.Microsoft.Configuration.Tests.csproj
+++ b/tests/Moq.Microsoft.Configuration.Tests/Moq.Microsoft.Configuration.Tests.csproj
@@ -10,13 +10,13 @@
 		<PackageReference Include="FluentAssertions" Version="5.10.3" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="5.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
 		<PackageReference Include="xunit" Version="2.4.1" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="coverlet.collector" Version="1.3.0">
+		<PackageReference Include="coverlet.collector" Version="3.1.0">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>

--- a/tests/Moq.Microsoft.Configuration.Tests/Moq.Microsoft.Configuration.Tests.csproj
+++ b/tests/Moq.Microsoft.Configuration.Tests/Moq.Microsoft.Configuration.Tests.csproj
@@ -9,6 +9,7 @@
 	<ItemGroup>
 		<PackageReference Include="FluentAssertions" Version="5.10.3" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="5.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
 		<PackageReference Include="xunit" Version="2.4.1" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">


### PR DESCRIPTION
Fix for #23 
- add a default setup for all sections
- add tests