### PR TITLE
create an empty configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 [![Nuget downloads](https://img.shields.io/nuget/dt/MoqMicrosoftConfiguration?label=nuget%20downloads&logo=nuget&style=plastic)](https://www.nuget.org/packages/MoqMicrosoftConfiguration/)   
 Moq for Microsoft.Extensions.Configuration
 ***
+Create empty Configuration sections or `Mock<IConfiguration>`. The latter way will not initialise any configuration sections.
+```cs
+var mockConfiguration = new EmptyMockConfiguration<IConfiguration>();
+var mockConfiguration = new EmptyMockConfiguration<IConfigurationRoot>();
+```
 Access values by specifying a path to the value in `[]` and with `:`.
 ```cs
 [Fact]

--- a/src/ConfigurationSetup.cs
+++ b/src/ConfigurationSetup.cs
@@ -19,5 +19,8 @@ namespace Moq.Microsoft.Configuration
 			
 			this.SetupConfigurationTree(param);
 		}
+
+		void ISetup<object>.ReturnsEmpty() =>
+			this.SetupConfigurationTree(EmptyModel.Instance);
 	}
 }

--- a/src/ConfigurationSetup.cs
+++ b/src/ConfigurationSetup.cs
@@ -2,14 +2,15 @@
 
 namespace Moq.Microsoft.Configuration
 {
-	internal sealed class ConfigurationSetup : ISetup<object>
+	internal sealed class ConfigurationSetup<T> : ISetup<object>
+		where T : class, IConfiguration
 	{
-		public ConfigurationSetup(Mock<IConfiguration> mockConfiguration)
+		public ConfigurationSetup(Mock<T> mockConfiguration)
 		{
 			MockConfiguration = mockConfiguration;
 		}
 
-		internal Mock<IConfiguration> MockConfiguration { get; }
+		internal Mock<T> MockConfiguration { get; }
 
 		public void Returns(object? param)
 		{

--- a/src/EmptyMockConfiguration.cs
+++ b/src/EmptyMockConfiguration.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.Extensions.Configuration;
+
+namespace Moq.Microsoft.Configuration
+{
+	public sealed class EmptyMockConfiguration<T> : Mock<T>
+		where T : class, IConfiguration
+	{
+		public EmptyMockConfiguration()
+		{
+			this.SetupConfiguration()
+				.ReturnsEmpty();
+		}
+	}
+}

--- a/src/Interfaces/ISetup.cs
+++ b/src/Interfaces/ISetup.cs
@@ -3,5 +3,7 @@
 	public interface ISetup<in T>
 	{
 		void Returns(T param);
+
+		internal void ReturnsEmpty();
 	}
 }

--- a/src/Models/EmptyModel.cs
+++ b/src/Models/EmptyModel.cs
@@ -1,0 +1,7 @@
+﻿namespace Moq.Microsoft.Configuration
+{
+	internal sealed class EmptyModel
+	{
+		public static readonly EmptyModel Instance = new();
+	}
+}

--- a/src/MoqConfigurationExtensions.cs
+++ b/src/MoqConfigurationExtensions.cs
@@ -5,7 +5,10 @@ namespace Moq.Microsoft.Configuration
 {
 	public static class MoqConfigurationExtensions
 	{
-		public static ISetup<object> SetupConfiguration(this Mock<IConfiguration> @this)
-			=> new ConfigurationSetup(@this);
+		public static ISetup<object> SetupConfiguration<T>(this Mock<T> @this)
+			where T : class, IConfiguration
+		{
+			return new ConfigurationSetup<T>(@this);
+		}
 	}
 }

--- a/src/Utils/Extensions/ConfigurationSetupEx.cs
+++ b/src/Utils/Extensions/ConfigurationSetupEx.cs
@@ -9,19 +9,20 @@ namespace Moq.Microsoft.Configuration
 	{
 		private static readonly SectionInfoProvider SectionInfoProvider = new();
 
-		public static void SetupConfigurationTree(this ConfigurationSetup @this, object configuration)
+		public static void SetupConfigurationTree<T>(this ConfigurationSetup<T> @this, object configuration)
+			where T : class, IConfiguration
 		{
 			var type = configuration.GetType();
 
 			if (IsPrimitive(type) || typeof(IEnumerable).IsAssignableFrom(type))
 				throw new InvalidOperationException($"A {type.FullName} cannot be set as the root because it does not have a root property");
 
+			@this.MockConfiguration.SetupDefaultSection();
+
 			var props = SectionInfoProvider.Resolve(type, configuration);
 
 			if (props.Count == 0)
-				throw new InvalidOperationException("The root element has no properties");
-
-			@this.MockConfiguration.SetupDefaultSection();
+				return;
 
 			var children = new IConfigurationSection[props.Count];
 			for (var i = 0; i < props.Count; i++)

--- a/src/Utils/Helpers/ConfigurationSection.cs
+++ b/src/Utils/Helpers/ConfigurationSection.cs
@@ -20,7 +20,7 @@ namespace Moq.Microsoft.Configuration
 		public string? Value { get; set; }
 
 		public IConfigurationSection GetSection(string key) =>
-			throw new System.NotImplementedException();
+			new ConfigurationSection(key);
 
 		public IEnumerable<IConfigurationSection> GetChildren() =>
 			Enumerable.Empty<IConfigurationSection>();

--- a/src/Utils/Helpers/ConfigurationSection.cs
+++ b/src/Utils/Helpers/ConfigurationSection.cs
@@ -7,10 +7,12 @@ namespace Moq.Microsoft.Configuration
 {
 	internal sealed class ConfigurationSection : IConfigurationSection
 	{
-		public ConfigurationSection(string key)
+		public ConfigurationSection(string key, string? path = null)
 		{
+			path ??= "Unknown";
+
 			Key = key;
-			Path = $"Unknown:{key}";
+			Path = $"{path}:{key}";
 		}
 
 		public string Key { get; }
@@ -20,7 +22,7 @@ namespace Moq.Microsoft.Configuration
 		public string? Value { get; set; }
 
 		public IConfigurationSection GetSection(string key) =>
-			new ConfigurationSection(key);
+			new ConfigurationSection(key, Path);
 
 		public IEnumerable<IConfigurationSection> GetChildren() =>
 			Enumerable.Empty<IConfigurationSection>();

--- a/tests/Moq.Microsoft.Configuration.Tests/EmptyMockConfigurationTests/EmptyMockConfigurationShould.cs
+++ b/tests/Moq.Microsoft.Configuration.Tests/EmptyMockConfigurationTests/EmptyMockConfigurationShould.cs
@@ -1,0 +1,54 @@
+﻿using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace Moq.Microsoft.Configuration.Tests.EmptyMockConfigurationTests
+{
+	public sealed class EmptyMockConfigurationShould : MockEmptyTestsBase
+	{
+		[Fact]
+		public void ReturnDefaultValue()
+		{
+			const int fallbackValue = 123;
+
+			var fixture = CreateClass();
+
+			var result = fixture.Object
+				.GetValue("key", fallbackValue);
+
+			result
+				.Should()
+				.Be(fallbackValue);
+		}
+
+		[Fact]
+		public void ReturnDefaultValuePath()
+		{
+			const int fallbackValue = 123;
+
+			var fixture = CreateClass();
+
+			var result = fixture.Object
+				.GetValue("section:key", fallbackValue);
+
+			result
+				.Should()
+				.Be(fallbackValue);
+		}
+
+		[Fact]
+		public void ReturnDefaultValueSection()
+		{
+			const int fallbackValue = 123;
+
+			var fixture = CreateClass();
+			var section = fixture.Object.GetSection("section");
+
+			var result = section.GetValue("key", fallbackValue);
+
+			result
+				.Should()
+				.Be(fallbackValue);
+		}
+	}
+}

--- a/tests/Moq.Microsoft.Configuration.Tests/MockEmptyTestsBase.cs
+++ b/tests/Moq.Microsoft.Configuration.Tests/MockEmptyTestsBase.cs
@@ -1,0 +1,10 @@
+﻿using Microsoft.Extensions.Configuration;
+
+namespace Moq.Microsoft.Configuration.Tests
+{
+	public abstract class MockEmptyTestsBase
+	{
+		protected static EmptyMockConfiguration<IConfiguration> CreateClass() =>
+			new();
+	}
+}

--- a/tests/Moq.Microsoft.Configuration.Tests/MockTestsBase.cs
+++ b/tests/Moq.Microsoft.Configuration.Tests/MockTestsBase.cs
@@ -4,7 +4,7 @@ namespace Moq.Microsoft.Configuration.Tests
 {
 	public abstract class MockTestsBase
 	{
-		protected Mock<IConfiguration> CreateClass() =>
-			new Mock<IConfiguration>();
+		protected static Mock<IConfiguration> CreateClass() =>
+			new();
 	}
 }


### PR DESCRIPTION
Issue: #28.
- allow mocks for any interface which implements `IConfiguration`
- create default empty configurations